### PR TITLE
Refactored code in src/user/jobs.js to reduce high complexity 

### DIFF
--- a/src/user/jobs.js
+++ b/src/user/jobs.js
@@ -7,60 +7,78 @@ const meta = require('../meta');
 
 const jobs = {};
 
-module.exports = function (User) {
-	User.startJobs = function () {
-		winston.verbose('[user/jobs] (Re-)starting jobs...');
-
-		let { digestHour } = meta.config;
-
-		// Fix digest hour if invalid
-		if (isNaN(digestHour)) {
-			digestHour = 17;
-		} else if (digestHour > 23 || digestHour < 0) {
-			digestHour = 0;
-		}
-
-		User.stopJobs();
-
-		startDigestJob('digest.daily', `0 ${digestHour} * * *`, 'day');
-		startDigestJob('digest.weekly', `0 ${digestHour} * * 0`, 'week');
-		startDigestJob('digest.monthly', `0 ${digestHour} 1 * *`, 'month');
-
-		jobs['reset.clean'] = new cronJob('0 0 * * *', User.reset.clean, null, true);
-		winston.verbose('[user/jobs] Starting job (reset.clean)');
-
-		winston.verbose(`[user/jobs] jobs started`);
-	};
-
-	function startDigestJob(name, cronString, term) {
-		jobs[name] = new cronJob(cronString, (async () => {
-			winston.verbose(`[user/jobs] Digest job (${name}) started.`);
-			try {
-				if (name === 'digest.weekly') {
-					const counter = await db.increment('biweeklydigestcounter');
-					if (counter % 2) {
-						await User.digest.execute({ interval: 'biweek' });
-					}
+function startDigestJob({name, cronString, term, user}) {
+	jobs[name] = new cronJob(cronString, (async () => {
+		winston.verbose(`[user/jobs] Digest job (${name}) started.`);
+		try {
+			if (name === 'digest.weekly') {
+				const counter = await db.increment('biweeklydigestcounter');
+				if (counter % 2) {
+					await user.digest.execute({ interval: 'biweek' });
 				}
-				await User.digest.execute({ interval: term });
-			} catch (err) {
-				winston.error(err.stack);
 			}
-		}), null, true);
-		winston.verbose(`[user/jobs] Starting job (${name})`);
+			await user.digest.execute({ interval: term });
+		} catch (err) {
+			winston.error(err.stack);
+		}
+	}), null, true);
+	winston.verbose(`[user/jobs] Starting job (${name})`);
+}
+
+function startJobs(user) {
+	winston.verbose('[user/jobs] (Re-)starting jobs...');
+
+	let { digestHour } = meta.config;
+
+	// Fix digest hour if invalid
+	if (isNaN(digestHour)) {
+		digestHour = 17;
+	} else if (digestHour > 23 || digestHour < 0) {
+		digestHour = 0;
 	}
 
-	User.stopJobs = function () {
-		let terminated = 0;
-		// Terminate any active cron jobs
-		for (const jobId of Object.keys(jobs)) {
-			winston.verbose(`[user/jobs] Terminating job (${jobId})`);
-			jobs[jobId].stop();
-			delete jobs[jobId];
-			terminated += 1;
-		}
-		if (terminated > 0) {
-			winston.verbose(`[user/jobs] ${terminated} jobs terminated`);
-		}
-	};
+	user.stopJobs();
+
+	startDigestJob({
+		name: 'digest.daily', 
+		cronString: `0 ${digestHour} * * *`, 
+		term: 'day', 
+		user: user,
+	});
+	startDigestJob({
+		name: 'digest.weekly', 
+		cronString: `0 ${digestHour} * * 0`, 
+		term: 'week', 
+		user: user,
+	});
+	startDigestJob({
+		name: 'digest.monthly', 
+		cronString: `0 ${digestHour} 1 * *`, 
+		term: 'month', 
+		user: user,
+	});
+
+	jobs['reset.clean'] = new cronJob('0 0 * * *', user.reset.clean, null, true);
+	winston.verbose('[user/jobs] Starting job (reset.clean)');
+
+	winston.verbose(`[user/jobs] jobs started`);
+};
+
+function stopJobs() {
+	let terminated = 0;
+	// Terminate any active cron jobs
+	for (const jobId of Object.keys(jobs)) {
+		winston.verbose(`[user/jobs] Terminating job (${jobId})`);
+		jobs[jobId].stop();
+		delete jobs[jobId];
+		terminated += 1;
+	}
+	if (terminated > 0) {
+		winston.verbose(`[user/jobs] ${terminated} jobs terminated`);
+	}
+};
+
+module.exports = function (User) {
+	User.startJobs = () => startJobs(User);
+	User.stopJobs = () => stopJobs();
 };


### PR DESCRIPTION
## Summary

Previously, the src/user/jobs.js file exported a single function, with three inner functions defined within it.

In this refactor:
- Moved the inner functions (startJobs, stopJobs, and the helper method) out of the exported function to reduce code complexity 

## Testing

Tested locally by adding a `console.log` and running the app with `./nodebb dev` to verify the changes were executed correctly.

Resolves #22 